### PR TITLE
ossl_json_f64() seems to be unused, remove it to avoid libm dependency 

### DIFF
--- a/include/internal/json_enc.h
+++ b/include/internal/json_enc.h
@@ -202,9 +202,6 @@ void ossl_json_u64(OSSL_JSON_ENC *json, uint64_t value);
 /* Encode a JSON integer from an int64_t. */
 void ossl_json_i64(OSSL_JSON_ENC *json, int64_t value);
 
-/* Encode a JSON number from a 64-bit floating point value. */
-void ossl_json_f64(OSSL_JSON_ENC *json, double value);
-
 /*
  * Encode a JSON UTF-8 string from a zero-terminated string. The string passed
  * can be freed immediately following the call to this function.

--- a/ssl/quic/json_enc.c
+++ b/ssl/quic/json_enc.c
@@ -11,7 +11,6 @@
 #include "internal/nelem.h"
 #include "internal/numbers.h"
 #include <string.h>
-#include <math.h>
 
 /*
  * wbuf
@@ -593,33 +592,6 @@ void ossl_json_i64(OSSL_JSON_ENC *json, int64_t value)
 
     if (quote && !ossl_json_in_error(json))
         json_write_char(json, '"');
-}
-
-/* Encode a JSON number from a 64-bit floating point value. */
-void ossl_json_f64(OSSL_JSON_ENC *json, double value)
-{
-    char buf[32];
-
-    if (!json_pre_item(json))
-        return;
-
-#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
-    {
-        int checks = isnan(value);
-# if !defined(OPENSSL_SYS_VMS)
-        checks |= isinf(value);
-# endif
-
-        if (checks) {
-            json_raise_error(json);
-            return;
-        }
-    }
-#endif
-
-    BIO_snprintf(buf, sizeof(buf), "%1.17g", value);
-    json_write_str(json, buf);
-    json_post_item(json);
 }
 
 /*

--- a/test/json_test.c
+++ b/test/json_test.c
@@ -119,7 +119,6 @@ typedef void (*fp_pz_type)(OSSL_JSON_ENC *, const void *, size_t);
 #define OPJ_BOOL(x)           OP_CALL_I(ossl_json_bool, (x))
 #define OPJ_U64(x)            OP_CALL_U64(ossl_json_u64, (x))
 #define OPJ_I64(x)            OP_CALL_I64(ossl_json_i64, (x))
-#define OPJ_F64(x)            OP_CALL_D(ossl_json_f64, (x))
 #define OPJ_KEY(x)            OP_CALL_P(ossl_json_key, (x))
 #define OPJ_STR(x)            OP_CALL_P(ossl_json_str, (x))
 #define OPJ_STR_LEN(x, xl)    OP_CALL_PZ(ossl_json_str_len, (x), (xl))


### PR DESCRIPTION
This update provides  a fix for compilation of OpenSSL on AIX in our environment and should be available in the next release of OpenSSL presumably version `3.5.1`.